### PR TITLE
fix(android): jumping back after drag

### DIFF
--- a/android/src/main/java/expo/modules/dragdropcontentview/ExpoDragDropContentView.kt
+++ b/android/src/main/java/expo/modules/dragdropcontentview/ExpoDragDropContentView.kt
@@ -134,7 +134,7 @@ class ExpoDragDropContentView(context: Context, appContext: AppContext) : ExpoVi
                 info?.let { infoList.add(it) }
             }
             onDropEvent(mapOf("assets" to infoList))
-            return@configureView payload
+            return@configureView null
         }
     }
 


### PR DESCRIPTION
This PR fixes the jumping back transition right after you dragged an image to a view