### PR TITLE
fix(ios): import react to resolve reactZIndexSortedSubviews build issue

### DIFF
--- a/packages/expo-drag-drop-content-view/ios/ExpoDragDropContentView.swift
+++ b/packages/expo-drag-drop-content-view/ios/ExpoDragDropContentView.swift
@@ -1,4 +1,5 @@
 import ExpoModulesCore
+import React
 
 // This view will be used as a native component. Make sure to inherit from `ExpoView`
 // to apply the proper styling (e.g. border radius and shadows).


### PR DESCRIPTION
## Summary

Resolves issue #28

Fixes an iOS Swift build failure with React Native 0.85 / Expo SDK 56 by importing `React` in `ExpoDragDropContentView.swift`.

`ExpoDragDropContentView` calls `reactZIndexSortedSubviews()`, which is provided by React Native’s `UIView+React` category. 

With newer React Native (0.85+) / Expo SDK (56+) versions, importing `ExpoModulesCore` alone does not make that React extension visible to Swift.

## Error

```text
cannot find 'reactZIndexSortedSubviews' in scope
```

## Testing

Verified in an Expo SDK 56 / React Native 0.85 app that the previous Swift compile error is resolved.

---

In the meantime you can use this patch:

```
diff --git a/ios/ExpoDragDropContentView.swift b/ios/ExpoDragDropContentView.swift
index 3f9a7d9..f3b16a4 100644
--- a/ios/ExpoDragDropContentView.swift
+++ b/ios/ExpoDragDropContentView.swift
@@ -1,4 +1,5 @@
 import ExpoModulesCore
+import React
 
 // This view will be used as a native component. Make sure to inherit from `ExpoView`
 // to apply the proper styling (e.g. border radius and shadows).
```