### PR TITLE
Blob URI support and opt-in base64 for web drops

### DIFF
--- a/apps/docs/docs/api/overview.mdx
+++ b/apps/docs/docs/api/overview.mdx
@@ -12,7 +12,7 @@
 | onEnter               | ✅  | ✅      | ✅  | A callback that is called when any source is dragged into the view's boundary (hovering begins).                                                                                                                                          |
 | onExit                | ✅  | ✅      | ✅  | A callback that is called when any source is dragged out of the view's boundary (hovering ends).                                                                                                                                          |
 | onDropListeningStart  | ❌  | ✅      | ❌  | A callback that is called for all `<DragDropContentView />` instances within the view port once any drag begins. Useful if you want to customize all drop areas as soon as any asset begins dragging. Refer to [Example](https://github.com/AlirezaHadjar/expo-drag-drop-content-view/tree/main/apps/example/src/components/IDragDropContentView/IDragDropContentView.tsx)                                                                                                                                     |
-| includeBase64         | ✅  | ✅      | ❌  | If `true`, creates a base64 string of the media (Avoid using on large media files due to performance). It is always `true` on `Web` since it is the only available source.                                                                                                                            |
+| includeBase64         | ✅  | ✅      | ✅  | If `true`, includes the base64 data URL of the asset in the `base64` field (avoid on large files due to performance).                                                                                                                                                                                |
 | draggableSources      | ✅  | ✅      | ✅  | Sources that can be dragged around the screen. Refer to [Draggable Source](#draggable-source).                                                                                                                                     |
 | allowedMimeTypes      | ✅  | ✅      | ✅  | An array of mime types that are allowed to be dropped.                                                                                                                                 |
 
@@ -20,8 +20,8 @@
 
 | key      | iOS | Android | Web | Description                                 |
 | -------- | --- | ------- | --- | ------------------------------------------- |
-| base64   | ✅  | ✅      | ✅  | The base64 string of the media (Optional on Android and iOS, but Required on Web)   |
-| uri      | ✅  | ✅      | ❌  | The file uri in app-specific cache storage.   |
+| base64   | ✅  | ✅      | ✅  | The base64 data URL of the asset. Included when `includeBase64` is `true`.          |
+| uri      | ✅  | ✅      | ✅  | The file uri. On Android and iOS this is the app-specific cache storage URI. On web this is a blob URI (`URL.createObjectURL`). Not present for plain-text drops. |
 | path     | ✅  | ✅      | ❌  | The original file path.                      |
 | width    | ✅  | ✅      | ✅  | Asset dimensions                            |
 | height   | ✅  | ✅      | ✅  | Asset dimensions                            |
@@ -34,4 +34,4 @@
 | key      | iOS | Android | Web | Description                                 |
 | -------- | --- | ------- | --- | ------------------------------------------- |
 | type     | ✅  | ✅      | ✅  | `image`, `video`, `text` or `file`   |
-| value    | ✅  | ✅      | ✅  | For `image`, `video` or `file`, pass file uri or their base64 string. And for `text` pass the text value    |
+| value    | ✅  | ✅      | ✅  | For `image`, `video` or `file`: pass a file URI on iOS/Android, or a base64 data URL on web. For `text`, pass the text value.    |

--- a/apps/docs/docs/api/overview.mdx
+++ b/apps/docs/docs/api/overview.mdx
@@ -22,7 +22,7 @@
 | -------- | --- | ------- | --- | ------------------------------------------- |
 | base64   | ✅  | ✅      | ✅  | The base64 data URL of the asset. Included when `includeBase64` is `true`.          |
 | uri      | ✅  | ✅      | ✅  | The file uri. On Android and iOS this is the app-specific cache storage URI. On web this is a blob URI (`URL.createObjectURL`). Not present for plain-text drops. |
-| [Symbol.dispose] | ❌  | ❌      | ✅  | Revokes the blob URI. Not called automatically — use `using asset = ...` (TypeScript 5.2+) or call `asset[Symbol.dispose]?.()` when done. `uri` is invalid after disposal. |
+| release  | ❌  | ❌      | ✅  | Revokes the blob URI. Not called automatically — call `asset.release?.()` when done, or use `useDropAssets()` for automatic cleanup. `uri` is invalid after calling. |
 | path     | ✅  | ✅      | ❌  | The original file path.                      |
 | width    | ✅  | ✅      | ✅  | Asset dimensions                            |
 | height   | ✅  | ✅      | ✅  | Asset dimensions                            |

--- a/apps/docs/docs/api/overview.mdx
+++ b/apps/docs/docs/api/overview.mdx
@@ -22,6 +22,7 @@
 | -------- | --- | ------- | --- | ------------------------------------------- |
 | base64   | ✅  | ✅      | ✅  | The base64 data URL of the asset. Included when `includeBase64` is `true`.          |
 | uri      | ✅  | ✅      | ✅  | The file uri. On Android and iOS this is the app-specific cache storage URI. On web this is a blob URI (`URL.createObjectURL`). Not present for plain-text drops. |
+| [Symbol.dispose] | ❌  | ❌      | ✅  | Revokes the blob URI. Not called automatically — use `using asset = ...` (TypeScript 5.2+) or call `asset[Symbol.dispose]?.()` when done. `uri` is invalid after disposal. |
 | path     | ✅  | ✅      | ❌  | The original file path.                      |
 | width    | ✅  | ✅      | ✅  | Asset dimensions                            |
 | height   | ✅  | ✅      | ✅  | Asset dimensions                            |

--- a/apps/docs/docs/limitations.mdx
+++ b/apps/docs/docs/limitations.mdx
@@ -12,4 +12,5 @@ sidebar_position: 4
 ## Web:
 
 - Dropping multiple media files is fully supported. However, for dragging, it is only available across different instances of `<DragDropContentView />`. For external dragging (to other websites or the desktop), you must pass only a single media file to the `draggableSources`.
-- The dropped files will not have `uri` or `path` properties. You can use `base64` or `text` properties to get the file content.
+- Dropped files include a blob URI in the `uri` property. The `path` property is not available on web. Use `text` for plain-text drops, or enable `includeBase64` to also receive a base64 data URL.
+- Blob URIs in `uri` hold memory until explicitly released. Call `URL.revokeObjectURL(asset.uri)` once you are done with each asset to avoid memory leaks.

--- a/apps/docs/docs/limitations.mdx
+++ b/apps/docs/docs/limitations.mdx
@@ -13,4 +13,4 @@ sidebar_position: 4
 
 - Dropping multiple media files is fully supported. However, for dragging, it is only available across different instances of `<DragDropContentView />`. For external dragging (to other websites or the desktop), you must pass only a single media file to the `draggableSources`.
 - Dropped files include a blob URI in the `uri` property. The `path` property is not available on web. Use `text` for plain-text drops, or enable `includeBase64` to also receive a base64 data URL.
-- Blob URIs in `uri` hold memory until explicitly released. Each asset provides `[Symbol.dispose]()` — call `asset[Symbol.dispose]?.()` manually, or use the `using` declaration (TypeScript 5.2+) per-asset (`using a = asset`). Note: `using` applies to individual assets, not to the array returned by `onDrop`.
+- Blob URIs in `uri` hold memory until explicitly released. Each asset exposes a `release()` method — call `asset.release?.()` when done, or use the `useDropAssets()` hook for automatic cleanup on unmount.

--- a/apps/docs/docs/limitations.mdx
+++ b/apps/docs/docs/limitations.mdx
@@ -13,4 +13,4 @@ sidebar_position: 4
 
 - Dropping multiple media files is fully supported. However, for dragging, it is only available across different instances of `<DragDropContentView />`. For external dragging (to other websites or the desktop), you must pass only a single media file to the `draggableSources`.
 - Dropped files include a blob URI in the `uri` property. The `path` property is not available on web. Use `text` for plain-text drops, or enable `includeBase64` to also receive a base64 data URL.
-- Blob URIs in `uri` hold memory until explicitly released. Call `URL.revokeObjectURL(asset.uri)` once you are done with each asset to avoid memory leaks.
+- Blob URIs in `uri` hold memory until explicitly released. Each asset provides `[Symbol.dispose]()` — call `asset[Symbol.dispose]?.()` manually, or use the `using` declaration (TypeScript 5.2+) per-asset (`using a = asset`). Note: `using` applies to individual assets, not to the array returned by `onDrop`.

--- a/apps/example/src/components/IDragDropContentView/IDragDropContentView.tsx
+++ b/apps/example/src/components/IDragDropContentView/IDragDropContentView.tsx
@@ -2,9 +2,10 @@ import {
   DragDropContentView,
   DragDropContentViewProps,
   DropAsset,
+  useDropAssets,
 } from "expo-drag-drop-content-view";
 import { Image } from "expo-image";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
 import {
   Pressable,
   StyleSheet,
@@ -82,32 +83,23 @@ export const IDragDropContentView: React.FC<DragDropContentViewProps> = (
   props
 ) => {
   usePermission();
-  const [sources, setSources] = useState<DropAsset[] | null>(null);
+  const { assets, onDrop: onDropAssets, clear } = useDropAssets();
   const [readyToReceive, setReadyToReceive] = useState(false);
   const [isActive, setIsActive] = useState(false);
-
-  const sourcesRef = useRef(sources);
-  useEffect(() => { sourcesRef.current = sources; });
-  useEffect(() => {
-    return () => sourcesRef.current?.forEach((asset) => asset[Symbol.dispose]?.());
-  }, []);
-
-  const handleClear = () => {
-    sources?.forEach((asset) => asset[Symbol.dispose]?.());
-    setSources(null);
-  };
 
   return (
     <DragDropContentView
       {...props}
       includeBase64={false}
       collapsable={true}
-      draggableSources={sources
-        ?.filter((source) => getSourceType(source) !== undefined)
-        ?.map((source) => ({
-          type: getSourceType(source)!,
-          value: source.uri || source.base64 || source.text || "",
-        }))}
+      draggableSources={assets
+        .map((source) => ({
+          type: getSourceType(source),
+          // Blob URIs (web) are not valid drag values — draggableSources requires a
+          // data URL on web. Prefer base64, fall back to uri only for native file paths.
+          value: source.base64 || source.text || (source.uri?.startsWith("blob:") ? "" : source.uri) || "",
+        }))
+        .filter((source) => source.value !== "")}
       onDropListeningStart={() => {
         setReadyToReceive(true);
       }}
@@ -122,14 +114,13 @@ export const IDragDropContentView: React.FC<DragDropContentViewProps> = (
         setReadyToReceive(false);
       }}
       onDrop={(event) => {
-        const newData = [...(sources ?? []), ...event.assets];
-        setSources(newData);
+        onDropAssets(event);
         props.onDrop?.(event);
       }}
       style={[styles.container, props.style]}
     >
-      {sources ? (
-        sources.map((source, index) => {
+      {assets.length > 0 ? (
+        assets.map((source, index) => {
           const uri = (source.uri ? source.uri : source.base64) || "";
           const rotation = Math.ceil(index / 2) * 5;
           const direction = index % 2 === 0 ? 1 : -1;
@@ -139,7 +130,7 @@ export const IDragDropContentView: React.FC<DragDropContentViewProps> = (
           return (
             <AnimatedPressable
               key={index}
-              onPress={handleClear}
+              onPress={clear}
               entering={FadeIn.springify().delay(index * 100)}
               style={[styles.sourceContainer, { transform: [{ rotate }] }]}
             >

--- a/apps/example/src/components/IDragDropContentView/IDragDropContentView.tsx
+++ b/apps/example/src/components/IDragDropContentView/IDragDropContentView.tsx
@@ -4,7 +4,7 @@ import {
   DropAsset,
 } from "expo-drag-drop-content-view";
 import { Image } from "expo-image";
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   Pressable,
   StyleSheet,
@@ -86,7 +86,16 @@ export const IDragDropContentView: React.FC<DragDropContentViewProps> = (
   const [readyToReceive, setReadyToReceive] = useState(false);
   const [isActive, setIsActive] = useState(false);
 
-  const handleClear = () => setSources(null);
+  const sourcesRef = useRef(sources);
+  useEffect(() => { sourcesRef.current = sources; });
+  useEffect(() => {
+    return () => sourcesRef.current?.forEach((asset) => asset[Symbol.dispose]?.());
+  }, []);
+
+  const handleClear = () => {
+    sources?.forEach((asset) => asset[Symbol.dispose]?.());
+    setSources(null);
+  };
 
   return (
     <DragDropContentView

--- a/packages/expo-drag-drop-content-view/README.md
+++ b/packages/expo-drag-drop-content-view/README.md
@@ -25,6 +25,20 @@ yarn add expo-drag-drop-content-view
 Run `npx pod-install` after installing the npm package.
 
 
+# TypeScript requirements
+
+The `DropAsset` type includes a `[Symbol.dispose]` key for blob URI cleanup on web. This requires `ESNext.Disposable` (or a superset such as `ESNext`) in your `tsconfig.json` `lib`:
+
+```json
+{
+  "compilerOptions": {
+    "lib": ["DOM", "ESNext", "ESNext.Disposable"]
+  }
+}
+```
+
+Without this, TypeScript will report `Property 'dispose' does not exist on type 'typeof Symbol'`.
+
 # Contributing
 
 Contributions are very welcome! Please refer to guidelines described in the [contributing guide]( https://github.com/expo/expo#contributing).

--- a/packages/expo-drag-drop-content-view/README.md
+++ b/packages/expo-drag-drop-content-view/README.md
@@ -25,19 +25,33 @@ yarn add expo-drag-drop-content-view
 Run `npx pod-install` after installing the npm package.
 
 
-# TypeScript requirements
+# Web blob URI cleanup
 
-The `DropAsset` type includes a `[Symbol.dispose]` key for blob URI cleanup on web. This requires `ESNext.Disposable` (or a superset such as `ESNext`) in your `tsconfig.json` `lib`:
+On web, dropped file assets carry a blob URI (`asset.uri`) created with `URL.createObjectURL`. Blob URIs hold memory until explicitly revoked — the recommended way to handle this is the `useDropAssets` hook, which revokes all URIs automatically on unmount and exposes a `clear()` method for manual flushing:
 
-```json
-{
-  "compilerOptions": {
-    "lib": ["DOM", "ESNext", "ESNext.Disposable"]
-  }
+```tsx
+import { DragDropContentView, useDropAssets } from "expo-drag-drop-content-view";
+
+export function DropZone() {
+  const { assets, onDrop, clear } = useDropAssets();
+
+  return (
+    <>
+      <DragDropContentView onDrop={onDrop} />
+      <button onClick={clear}>Clear</button>
+    </>
+  );
 }
 ```
 
-Without this, TypeScript will report `Property 'dispose' does not exist on type 'typeof Symbol'`.
+If you manage assets yourself, call `asset.release?.()` when you're done with each one:
+
+```ts
+onDrop({ assets }) {
+  // use assets ...
+  assets.forEach((a) => a.release?.());
+}
+```
 
 # Contributing
 

--- a/packages/expo-drag-drop-content-view/src/ExpoDragDropContentView.web.tsx
+++ b/packages/expo-drag-drop-content-view/src/ExpoDragDropContentView.web.tsx
@@ -4,55 +4,57 @@ import { StyleSheet, View } from "react-native";
 
 import { DragDropContentViewProps, DropAsset } from "./types";
 
-let DragType: string = "";
 type DragDataItem = { type: string; value: string };
-let DragData: DragDataItem[] = [];
 
 
-const handleFile = (file: File, includeBase64: boolean): Promise<DropAsset> => {
-  return new Promise<DropAsset>((resolve) => {
-    const blobUri = URL.createObjectURL(file);
-    const isImage = file.type.startsWith("image/");
+const handleFile = async (
+  file: File,
+  includeBase64: boolean,
+  pendingBlobs: Set<string>,
+): Promise<DropAsset | null> => {
+  const blobUri = URL.createObjectURL(file);
+  pendingBlobs.add(blobUri);
+  const dispose = () => URL.revokeObjectURL(blobUri);
 
-    const buildAsset = (base64?: string) => {
-      if (!isImage) {
-        resolve({
-          uri: blobUri,
-          path: undefined,
-          type: file.type,
-          base64,
-          fileName: file.name,
-          [Symbol.dispose]() { URL.revokeObjectURL(blobUri); },
-        });
-        return;
-      }
-      const media = new Image();
-      media.src = blobUri;
-      const onDone = () => {
-        resolve({
-          uri: blobUri,
-          path: undefined,
-          type: file.type,
-          base64,
-          fileName: file.name,
-          width: media.naturalWidth,
-          height: media.naturalHeight,
-          [Symbol.dispose]() { URL.revokeObjectURL(blobUri); },
-        });
-      };
-      media.onload = onDone;
-      media.onerror = onDone;
-    };
-
-    if (includeBase64) {
+  let base64: string | undefined;
+  if (includeBase64) {
+    base64 = await new Promise<string | undefined>((res) => {
       const reader = new FileReader();
-      reader.onload = (e) => buildAsset(e.target?.result as string);
-      reader.onerror = () => buildAsset();
+      reader.onload = (e) => res(e.target?.result as string);
+      reader.onerror = () => res(undefined);
       reader.readAsDataURL(file);
-    } else {
-      buildAsset();
+    });
+    if (base64 === undefined) {
+      pendingBlobs.delete(blobUri);
+      URL.revokeObjectURL(blobUri);
+      return null;
     }
-  });
+  }
+
+  let width: number | undefined;
+  let height: number | undefined;
+  if (file.type.startsWith("image/")) {
+    try {
+      const bitmap = await createImageBitmap(file);
+      width = bitmap.width;
+      height = bitmap.height;
+      bitmap.close();
+    } catch {
+      // unsupported format or decode error — proceed without dimensions
+    }
+  }
+
+  const asset: DropAsset = {
+    uri: blobUri,
+    path: undefined,
+    type: file.type,
+    ...(base64 !== undefined && { base64 }),
+    fileName: file.name,
+    ...(width !== undefined && { width, height }),
+    release: dispose,
+  };
+  pendingBlobs.delete(blobUri);
+  return asset;
 };
 
 const getBase64 = (data: string): DropAsset => {
@@ -105,22 +107,22 @@ const getAssets = async (
   dataTransfer: DataTransfer,
   allowedMimeTypes?: (string | RegExp)[],
   includeBase64: boolean = false,
+  pendingBlobs: Set<string> = new Set(),
+  dragType: string = "",
+  dragData: DragDataItem[] = [],
 ) => {
   const resolvedFiles: (DropAsset | null)[] = [];
   const filePromises: Promise<DropAsset | null>[] = [];
   const textData = dataTransfer.getData("text/plain");
   const htmlData = dataTransfer.getData("text/html");
-  const isCustomDrag = DragType === "Custom Drag";
+  const isCustomDrag = dragType === "Custom Drag";
 
   const hasFiles =
     Array.from(dataTransfer.items ?? []).some((i) => i.kind === "file") ||
     dataTransfer.files.length > 0;
 
-  if (textData && !isCustomDrag && !hasFiles) {
-    // For text, check if text/plain is allowed
-    if (isMimeTypeAllowed("text/plain", allowedMimeTypes)) {
-      filePromises.push(handleText(textData));
-    }
+  if (textData && !isCustomDrag && !hasFiles && isMimeTypeAllowed("text/plain", allowedMimeTypes)) {
+    filePromises.push(handleText(textData));
   }
 
   // Dragging from the file system
@@ -134,7 +136,7 @@ const getAssets = async (
 
           // Check if the file's MIME type is allowed
           if (isMimeTypeAllowed(file.type, allowedMimeTypes)) {
-            filePromises.push(handleFile(file, includeBase64));
+            filePromises.push(handleFile(file, includeBase64, pendingBlobs));
           }
         }
       }
@@ -144,7 +146,7 @@ const getAssets = async (
 
         // Check if the file's MIME type is allowed
         if (isMimeTypeAllowed(file.type, allowedMimeTypes)) {
-          filePromises.push(handleFile(file, includeBase64));
+          filePromises.push(handleFile(file, includeBase64, pendingBlobs));
         }
       }
     }
@@ -154,7 +156,7 @@ const getAssets = async (
   if (isCustomDrag) {
     const droppedSources: DragDataItem[] = []; // base64 strings
 
-    DragData.forEach((data) => {
+    dragData.forEach((data) => {
       // For custom drag, we need to extract MIME type from base64 data
       if (data.type === "text") {
         if (isMimeTypeAllowed("text/plain", allowedMimeTypes)) {
@@ -197,9 +199,6 @@ const getAssets = async (
 
   resolvedFiles.push(...(await Promise.all(filePromises)));
 
-  DragData = [];
-  DragType = "";
-
   // Filter out null values (failed handleFile calls)
   return resolvedFiles.filter((file) => file !== null) as DropAsset[];
 };
@@ -210,13 +209,21 @@ export default class ExpoDragDropContentView extends React.PureComponent<DragDro
   private id: string =
     "id-" + (Math.random() * 10000000000).toFixed(0).toString();
   private target: EventTarget | null = null;
+  private pendingBlobs = new Set<string>();
+  private _mounted = false;
+  private _dragType = "";
+  private _dragData: DragDataItem[] = [];
 
   componentDidMount() {
+    this._mounted = true;
     this.setupDragDropListeners();
   }
 
   componentWillUnmount() {
+    this._mounted = false;
     this.removeDragDropListeners();
+    this.pendingBlobs.forEach((uri) => URL.revokeObjectURL(uri));
+    this.pendingBlobs.clear();
   }
 
   handleDragEnter = (event: Event) => {
@@ -243,12 +250,27 @@ export default class ExpoDragDropContentView extends React.PureComponent<DragDro
     event.preventDefault();
     this.props.onDragEnd?.();
 
-    const assets = await getAssets(
-      event.dataTransfer,
-      this.props.allowedMimeTypes,
-      this.props.includeBase64 ?? false,
-    );
-    if (assets.length > 0) this.props.onDrop?.({ assets });
+    try {
+      const assets = await getAssets(
+        event.dataTransfer,
+        this.props.allowedMimeTypes,
+        this.props.includeBase64 ?? false,
+        this.pendingBlobs,
+        this._dragType,
+        this._dragData,
+      );
+      if (this._mounted && assets.length > 0) {
+        this.props.onDrop?.({ assets });
+      } else {
+        assets.forEach((a) => a.release?.());
+      }
+    } catch {
+      // getAssets failed (e.g. URL.createObjectURL threw on detached document).
+      // onDragEnd already fired and reset drag state; nothing more to do.
+    } finally {
+      this._dragType = "";
+      this._dragData = [];
+    }
   };
 
   handleDragStart = async <T extends Event & { dataTransfer: DataTransfer }>(
@@ -260,9 +282,10 @@ export default class ExpoDragDropContentView extends React.PureComponent<DragDro
 
     if (!preview || !sources) return;
 
-    DragType = "Custom Drag";
-    sources.forEach((source, index) => {
-      DragData.push({ type: source.type, value: source.value });
+    this._dragType = "Custom Drag";
+    this._dragData = [];
+    sources.forEach((source) => {
+      this._dragData.push({ type: source.type, value: source.value });
     });
 
     // Both images and videos can be dragged
@@ -301,6 +324,7 @@ export default class ExpoDragDropContentView extends React.PureComponent<DragDro
 
     if (!domElement) return;
 
+    domElement.removeEventListener("dragstart", this.handleDragStart as any);
     domElement.removeEventListener("dragenter", this.handleDragEnter);
     domElement.removeEventListener("dragleave", this.handleDragLeave);
     domElement.removeEventListener("dragover", this.handleDragOver);

--- a/packages/expo-drag-drop-content-view/src/ExpoDragDropContentView.web.tsx
+++ b/packages/expo-drag-drop-content-view/src/ExpoDragDropContentView.web.tsx
@@ -8,45 +8,52 @@ let DragType: string = "";
 type DragDataItem = { type: string; value: string };
 let DragData: DragDataItem[] = [];
 
-const handleFile = (file: File) => {
+
+const handleFile = (file: File, includeBase64: boolean): Promise<DropAsset> => {
   return new Promise<DropAsset>((resolve) => {
-    const reader = new FileReader();
+    const blobUri = URL.createObjectURL(file);
+    const isImage = file.type.startsWith("image/");
 
-    reader.onload = (e) => {
-      const dataURL = e.target?.result;
-
+    const buildAsset = (base64?: string) => {
+      if (!isImage) {
+        resolve({
+          uri: blobUri,
+          path: undefined,
+          type: file.type,
+          base64,
+          fileName: file.name,
+        });
+        return;
+      }
       const media = new Image();
-      media.src = dataURL as string;
-
-      media.onload = () => {
+      media.src = blobUri;
+      const onDone = () => {
         resolve({
-          uri: undefined,
+          uri: blobUri,
           path: undefined,
           type: file.type,
-          base64: media.src,
+          base64,
           fileName: file.name,
           width: media.naturalWidth,
           height: media.naturalHeight,
         });
       };
-      media.onerror = () => {
-        resolve({
-          uri: undefined,
-          path: undefined,
-          type: file.type,
-          base64: media.src,
-          fileName: file.name,
-          width: media.naturalWidth,
-          height: media.naturalHeight,
-        });
-      };
+      media.onload = onDone;
+      media.onerror = onDone;
     };
 
-    reader.readAsDataURL(file);
+    if (includeBase64) {
+      const reader = new FileReader();
+      reader.onload = (e) => buildAsset(e.target?.result as string);
+      reader.onerror = () => buildAsset();
+      reader.readAsDataURL(file);
+    } else {
+      buildAsset();
+    }
   });
 };
 
-const getBase64 = (data: string) => {
+const getBase64 = (data: string): DropAsset => {
   const extension =
     data?.split(";")?.[0]?.split(":")?.[1]?.split("/")?.[1] || "jpeg";
   const kind =
@@ -56,7 +63,6 @@ const getBase64 = (data: string) => {
   const fileName = `${kind}.${extension}`;
 
   return {
-    uri: undefined,
     path: undefined,
     type,
     base64: data,
@@ -75,7 +81,7 @@ const handleText = (text: string) => {
 // MIME Type Filtering Utils
 const isMimeTypeAllowed = (
   mimeType: string,
-  allowedMimeTypes?: (string | RegExp)[]
+  allowedMimeTypes?: (string | RegExp)[],
 ): boolean => {
   if (allowedMimeTypes === undefined || allowedMimeTypes === null) {
     return true; // If undefined or null, allow all
@@ -95,7 +101,8 @@ const isMimeTypeAllowed = (
 
 const getAssets = async (
   dataTransfer: DataTransfer,
-  allowedMimeTypes?: (string | RegExp)[]
+  allowedMimeTypes?: (string | RegExp)[],
+  includeBase64: boolean = false,
 ) => {
   const resolvedFiles: (DropAsset | null)[] = [];
   const filePromises: Promise<DropAsset | null>[] = [];
@@ -103,7 +110,11 @@ const getAssets = async (
   const htmlData = dataTransfer.getData("text/html");
   const isCustomDrag = DragType === "Custom Drag";
 
-  if (textData && !isCustomDrag) {
+  const hasFiles =
+    Array.from(dataTransfer.items ?? []).some((i) => i.kind === "file") ||
+    dataTransfer.files.length > 0;
+
+  if (textData && !isCustomDrag && !hasFiles) {
     // For text, check if text/plain is allowed
     if (isMimeTypeAllowed("text/plain", allowedMimeTypes)) {
       filePromises.push(handleText(textData));
@@ -121,7 +132,7 @@ const getAssets = async (
 
           // Check if the file's MIME type is allowed
           if (isMimeTypeAllowed(file.type, allowedMimeTypes)) {
-            filePromises.push(handleFile(file));
+            filePromises.push(handleFile(file, includeBase64));
           }
         }
       }
@@ -131,7 +142,7 @@ const getAssets = async (
 
         // Check if the file's MIME type is allowed
         if (isMimeTypeAllowed(file.type, allowedMimeTypes)) {
-          filePromises.push(handleFile(file));
+          filePromises.push(handleFile(file, includeBase64));
         }
       }
     }
@@ -162,7 +173,7 @@ const getAssets = async (
       ...droppedSources.map((item) => {
         if (item.type === "text") return { type: item.type, text: item.value };
         return getBase64(item.value);
-      })
+      }),
     );
   }
   // Dragging from other web pages
@@ -225,20 +236,21 @@ export default class ExpoDragDropContentView extends React.PureComponent<DragDro
   };
 
   handleDrop = async <T extends Event & { dataTransfer: DataTransfer }>(
-    event: T
+    event: T,
   ) => {
     event.preventDefault();
     this.props.onDragEnd?.();
 
     const assets = await getAssets(
       event.dataTransfer,
-      this.props.allowedMimeTypes
+      this.props.allowedMimeTypes,
+      this.props.includeBase64 ?? false,
     );
     if (assets.length > 0) this.props.onDrop?.({ assets });
   };
 
   handleDragStart = async <T extends Event & { dataTransfer: DataTransfer }>(
-    event: T
+    event: T,
   ) => {
     this.props.onDragStart?.();
     const sources = this.props.draggableSources;

--- a/packages/expo-drag-drop-content-view/src/ExpoDragDropContentView.web.tsx
+++ b/packages/expo-drag-drop-content-view/src/ExpoDragDropContentView.web.tsx
@@ -22,6 +22,7 @@ const handleFile = (file: File, includeBase64: boolean): Promise<DropAsset> => {
           type: file.type,
           base64,
           fileName: file.name,
+          [Symbol.dispose]() { URL.revokeObjectURL(blobUri); },
         });
         return;
       }
@@ -36,6 +37,7 @@ const handleFile = (file: File, includeBase64: boolean): Promise<DropAsset> => {
           fileName: file.name,
           width: media.naturalWidth,
           height: media.naturalHeight,
+          [Symbol.dispose]() { URL.revokeObjectURL(blobUri); },
         });
       };
       media.onload = onDone;

--- a/packages/expo-drag-drop-content-view/src/index.ts
+++ b/packages/expo-drag-drop-content-view/src/index.ts
@@ -1,3 +1,4 @@
 export { default as DragDropContentView } from "./ExpoDragDropContentView";
 
-export type { DragDropContentViewProps, DropAsset } from "./types";
+export type { DragDropContentViewProps, DropAsset, Assets } from "./types";
+export { useDropAssets } from "./useDropAssets";

--- a/packages/expo-drag-drop-content-view/src/types.ts
+++ b/packages/expo-drag-drop-content-view/src/types.ts
@@ -2,18 +2,16 @@ import { ViewProps } from "react-native";
 
 export type DropAsset = {
   /**
-   * @platform Android, iOS
-   * @description The file uri in app-specific cache storage.
+   * @description The file uri. On Android and iOS this is the app-specific cache storage URI. On web this is a blob URI created with `URL.createObjectURL`. Not present for plain-text drops.
+   * @web Consumers are responsible for calling `URL.revokeObjectURL(uri)` when done to free memory.
    */
-  uri?: string | undefined;
+  uri?: string;
   /**
    * @description The mime type of the file.
    */
   type: string;
   /**
-   * @platform Android, iOS
-   * @description The base64 string of the image
-   * @optional
+   * @description The base64 data URL of the asset. Included when `includeBase64` prop is true.
    */
   base64?: string;
   /**
@@ -83,7 +81,7 @@ export type DragDropContentViewProps = ViewProps & {
   allowedMimeTypes?: (string | RegExp)[];
   /**
    * @description The source of the image or/and video or/and text that can be dragged around the screen.
-   * @description Pass Uri on iOS and Android, and base64 on Web.
+   * @description Pass a URI on iOS and Android. On web, pass a base64 data URL.
    */
   draggableSources?: {
     type: "text" | "image" | "video" | "file";

--- a/packages/expo-drag-drop-content-view/src/types.ts
+++ b/packages/expo-drag-drop-content-view/src/types.ts
@@ -3,7 +3,7 @@ import { ViewProps } from "react-native";
 export type DropAsset = {
   /**
    * @description The file uri. On Android and iOS this is the app-specific cache storage URI. On web this is a blob URI created with `URL.createObjectURL`. Not present for plain-text drops.
-   * @web A blob URI — must be explicitly released. Call `asset[Symbol.dispose]?.()` when done, or use the `using` declaration (TypeScript 5.2+) per-asset (`using a = asset`). Note: `using` works on individual assets, not on the array from `onDrop`. The URI is invalid after disposal.
+   * @web A blob URI — must be explicitly released. Call `asset.release?.()` when done, or use `useDropAssets()` for automatic cleanup. The URI is invalid after release.
    */
   uri?: string;
   /**
@@ -36,9 +36,11 @@ export type DropAsset = {
    */
   text?: string;
   /**
-   * @web Revokes the blob URI — `uri` is invalid after calling. Not called automatically; use the `using` declaration (TypeScript 5.2+) or call it manually. Not present on native or for text-only drops.
+   * @web Revokes the blob URI — `uri` is invalid after calling. Not called automatically.
+   * Not present on native or for text-only drops.
+   * Use `useDropAssets()` for automatic cleanup, or call this manually when done.
    */
-  [Symbol.dispose]?: () => void;
+  release?: () => void;
 };
 
 export type Assets = { assets: DropAsset[] };

--- a/packages/expo-drag-drop-content-view/src/types.ts
+++ b/packages/expo-drag-drop-content-view/src/types.ts
@@ -3,7 +3,7 @@ import { ViewProps } from "react-native";
 export type DropAsset = {
   /**
    * @description The file uri. On Android and iOS this is the app-specific cache storage URI. On web this is a blob URI created with `URL.createObjectURL`. Not present for plain-text drops.
-   * @web Consumers are responsible for calling `URL.revokeObjectURL(uri)` when done to free memory.
+   * @web A blob URI — must be explicitly released. Call `asset[Symbol.dispose]?.()` when done, or use the `using` declaration (TypeScript 5.2+) per-asset (`using a = asset`). Note: `using` works on individual assets, not on the array from `onDrop`. The URI is invalid after disposal.
    */
   uri?: string;
   /**
@@ -35,6 +35,10 @@ export type DropAsset = {
    * @description If the dropped file is text, this key contains its value
    */
   text?: string;
+  /**
+   * @web Revokes the blob URI — `uri` is invalid after calling. Not called automatically; use the `using` declaration (TypeScript 5.2+) or call it manually. Not present on native or for text-only drops.
+   */
+  [Symbol.dispose]?: () => void;
 };
 
 export type Assets = { assets: DropAsset[] };

--- a/packages/expo-drag-drop-content-view/src/useDropAssets.ts
+++ b/packages/expo-drag-drop-content-view/src/useDropAssets.ts
@@ -1,0 +1,23 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { Assets, DropAsset } from "./types";
+
+export function useDropAssets() {
+  const [assets, setAssets] = useState<DropAsset[]>([]);
+  const releasers = useRef<Array<() => void>>([]);
+
+  const onDrop = useCallback(({ assets: incoming }: Assets) => {
+    incoming.forEach((a) => { if (a.release) releasers.current.push(a.release); });
+    setAssets((prev) => [...prev, ...incoming]);
+  }, []);
+
+  const clear = useCallback(() => {
+    releasers.current.forEach((r) => r());
+    releasers.current = [];
+    setAssets([]);
+  }, []);
+
+  useEffect(() => () => { releasers.current.forEach((r) => r()); }, []);
+
+  return { assets, onDrop, clear };
+}


### PR DESCRIPTION
Previously web assets had no uri and always included base64, making large file drops expensive. Now URL.createObjectURL is used to populate uri on all file drops, and base64 is only included when includeBase64 is true, consistent with native behaviour.